### PR TITLE
Bugfix/phonenumbertop

### DIFF
--- a/ui-app/client/src/components/PageEditor/editors/PropertyEditor.tsx
+++ b/ui-app/client/src/components/PageEditor/editors/PropertyEditor.tsx
@@ -58,6 +58,7 @@ function updatePropertyDefinition(
 	) as PageDefinition;
 
 	for (let component of componentList?.length > 0 ? componentList : [componentKey]) {
+		if (!pageDef) continue;
 		if (!pageDef.componentDefinition[component].properties)
 			pageDef.componentDefinition[component].properties = {};
 

--- a/ui-app/client/src/components/PhoneNumber/PhoneNumber.tsx
+++ b/ui-app/client/src/components/PhoneNumber/PhoneNumber.tsx
@@ -40,6 +40,7 @@ function PhoneNumber(props: Readonly<ComponentProps>) {
 	};
 	const countryMap = useRef(new Map<string, DropdownOption>());
 	const lastSelectedCountry = useRef<DropdownOption | null>(null);
+	const isFirstRender = useRef(true);
 
 	const {
 		definition: { bindingPath },
@@ -318,6 +319,7 @@ function PhoneNumber(props: Readonly<ComponentProps>) {
 		if (countryMap.current.has(dc)) return countryMap.current.get(dc);
 		return temp[0];
 	};
+
 	const getUnformattedNumber = (text: string | undefined) => {
 		if (!text) return '';
 		return text.replace(/[^+\d]/g, '');
@@ -376,13 +378,12 @@ function PhoneNumber(props: Readonly<ComponentProps>) {
 			tempList = duplicate(SORTED_COUNTRY_LIST);
 		}
 
-		if (tempList.length > 0) {
-			const indiaOption = tempList.find((country: DropdownOption) => country.C === 'IN');
-			setSelected(indiaOption);
-			lastSelectedCountry.current = indiaOption;
-		}
-
 		setCountryList(tempList);
+		if (isFirstRender.current && tempList.length > 0) {
+			setSelected(tempList[0]);
+			lastSelectedCountry.current = tempList[0];
+			isFirstRender.current = false;
+		}
 	}, [countries, topCountries, SORTED_COUNTRY_LIST]);
 
 	useEffect(() => {

--- a/ui-app/client/src/components/PhoneNumber/PhoneNumber.tsx
+++ b/ui-app/client/src/components/PhoneNumber/PhoneNumber.tsx
@@ -375,6 +375,13 @@ function PhoneNumber(props: Readonly<ComponentProps>) {
 		} else {
 			tempList = duplicate(SORTED_COUNTRY_LIST);
 		}
+
+		if (tempList.length > 0) {
+			const indiaOption = tempList.find((country: DropdownOption) => country.C === 'IN');
+			setSelected(indiaOption);
+			lastSelectedCountry.current = indiaOption;
+		}
+
 		setCountryList(tempList);
 	}, [countries, topCountries, SORTED_COUNTRY_LIST]);
 

--- a/ui-app/client/src/components/PhoneNumber/PhoneNumber.tsx
+++ b/ui-app/client/src/components/PhoneNumber/PhoneNumber.tsx
@@ -43,7 +43,7 @@ function PhoneNumber(props: Readonly<ComponentProps>) {
 	const isFirstRender = useRef(true);
 
 	const {
-		definition: { bindingPath },
+		definition: { bindingPath, bindingPath2 },
 		definition,
 		pageDefinition: { translations },
 		locationHistory,
@@ -95,9 +95,14 @@ function PhoneNumber(props: Readonly<ComponentProps>) {
 		pageExtractor,
 	);
 	const [value, setValue] = React.useState<string>('');
+	const [countryCode, setCountryCode] = React.useState<string>('');
 
 	const bindingPathPath = bindingPath
 		? getPathFromLocation(bindingPath, locationHistory, pageExtractor)
+		: undefined;
+
+	const bindingPathPath2 = bindingPath2
+		? getPathFromLocation(bindingPath2, locationHistory, pageExtractor)
 		: undefined;
 
 	React.useEffect(() => {
@@ -114,6 +119,27 @@ function PhoneNumber(props: Readonly<ComponentProps>) {
 			bindingPathPath,
 		);
 	}, [bindingPathPath]);
+
+	React.useEffect(() => {
+		if (!bindingPathPath2) return;
+		return addListenerAndCallImmediately(
+			(_, value) => {
+				if (isNullValue(value)) {
+					setCountryCode('');
+					return;
+				}
+				setCountryCode(value);
+				// Find and set the country based on country code
+				const country = SORTED_COUNTRY_LIST.find(c => c.C === value);
+				if (country) {
+					setSelected(country);
+					lastSelectedCountry.current = country;
+				}
+			},
+			pageExtractor,
+			bindingPathPath2,
+		);
+	}, [bindingPathPath2]);
 
 	const spinnerPath1 = onEnter
 		? `${STORE_PATH_FUNCTION_EXECUTION}.${props.context.pageName}.${flattenUUID(
@@ -319,7 +345,6 @@ function PhoneNumber(props: Readonly<ComponentProps>) {
 		if (countryMap.current.has(dc)) return countryMap.current.get(dc);
 		return temp[0];
 	};
-
 	const getUnformattedNumber = (text: string | undefined) => {
 		if (!text) return '';
 		return text.replace(/[^+\d]/g, '');
@@ -377,11 +402,14 @@ function PhoneNumber(props: Readonly<ComponentProps>) {
 		} else {
 			tempList = duplicate(SORTED_COUNTRY_LIST);
 		}
-
 		setCountryList(tempList);
+
 		if (isFirstRender.current && tempList.length > 0) {
 			setSelected(tempList[0]);
 			lastSelectedCountry.current = tempList[0];
+			if (bindingPathPath2) {
+				setData(bindingPathPath2, tempList[0].C, context?.pageName);
+			}
 			isFirstRender.current = false;
 		}
 	}, [countries, topCountries, SORTED_COUNTRY_LIST]);
@@ -497,6 +525,21 @@ function PhoneNumber(props: Readonly<ComponentProps>) {
 		lastSelectedCountry.current = v;
 		countryMap.current.clear();
 		countryMap.current.set(v.D, v);
+
+		if (bindingPathPath) {
+			const formattedPhone = format
+				? storeFormatted
+					? seperator + getFormattedNumber(phoneNumber, v.D)
+					: phoneNumber
+				: phoneNumber;
+			const newValue = phoneNumber ? v.D + formattedPhone : '';
+			setData(bindingPathPath, newValue, context?.pageName);
+		}
+
+		if (bindingPathPath2) {
+			setData(bindingPathPath2, v.C, context?.pageName);
+			callChangeEvent();
+		}
 	};
 
 	const leftChildren = (
@@ -574,7 +617,8 @@ const component: Component = {
 	stylePseudoStates: ['focus', 'disabled'],
 	styleProperties: stylePropertiesDefinition,
 	bindingPaths: {
-		bindingPath: { name: 'Phone Binding' },
+		bindingPath: { name: 'Phone Number Binding' },
+		bindingPath2: { name: 'Country Code Binding' },
 	},
 	defaultTemplate: {
 		key: '',

--- a/ui-app/client/src/components/PhoneNumber/phoneNumberProperties.ts
+++ b/ui-app/client/src/components/PhoneNumber/phoneNumberProperties.ts
@@ -62,7 +62,7 @@ const propertiesDefinition: Array<ComponentPropertyDefinition> = [
 	{
 		name: 'format',
 		schema: SCHEMA_BOOL_COMP_PROP,
-		displayName: 'Formar Number',
+		displayName: 'Format Number',
 		description: 'Format Phone Number.',
 		defaultValue: true,
 		group: ComponentPropertyGroup.BASIC,


### PR DESCRIPTION

Updated the logic to ensure the phone number is updated by default.
Added binding for the country code.

PropertyEditor.tsx

Added a check to continue if pageDef is not defined.
PhoneNumber.tsx

Added state and logic to handle the country code.
Ensured the country code is set correctly based on the selected country.
Included handling for the first render to set default country code and phone number.
phoneNumberProperties.ts

Fixed a typo in the property display name from "Formar Number" to "Format Number".