### PR TITLE
Adjust label position calculation in TextArea styles

### DIFF
--- a/ui-app/client/src/components/TextArea/TextAreaStyle.tsx
+++ b/ui-app/client/src/components/TextArea/TextAreaStyle.tsx
@@ -52,7 +52,7 @@ export default function TextAreaStyle({
 	
 		${PREFIX}._isActive ._label,
 		${PREFIX} ._label._noFloat {
-			transform: translateY(-150%);
+			transform: translateY(calc(-150% - 7px));
 		}
 	
 		${PREFIX}._hasLeftIcon ._label {


### PR DESCRIPTION
Modified the label transform to account for an additional 7px offset. This ensures proper alignment and avoids visual inconsistencies in specific scenarios.