### PR TITLE
Add multiple file selection option to File Selector

### DIFF
--- a/ui-app/client/src/commonComponents/FileBrowser/LazyFileBrowser.tsx
+++ b/ui-app/client/src/commonComponents/FileBrowser/LazyFileBrowser.tsx
@@ -121,7 +121,6 @@ export default function FileBrowser({
 		(async () => {
 			try {
 				let url = `/api/files/${resourceType}${path}?size=200`;
-				console.log(url, path);
 				if (fileCategory?.length) url += `&fileType=${fileCategory}`;
 				if (filter.trim() !== '') url += `&filter=${filter}`;
 				if (clientCode) url += `&clientCode=${clientCode}`;

--- a/ui-app/client/src/components/FileSelector/FileSelector.tsx
+++ b/ui-app/client/src/components/FileSelector/FileSelector.tsx
@@ -63,6 +63,7 @@ function FileSelector(props: Readonly<ComponentProps>) {
 			cropToAspectRatio,
 			editOnUpload,
 			clientCode,
+			allowMultipleSelection,
 		} = {},
 		stylePropertiesWithPseudoStates,
 	} = useDefinition(
@@ -215,6 +216,7 @@ function FileSelector(props: Readonly<ComponentProps>) {
 								cropToAspectRatio={cropToAspectRatio}
 								editOnUpload={editOnUpload}
 								clientCode={clientCode}
+								allowMultipleSelection={allowMultipleSelection}
 							/>
 						</div>
 					</div>

--- a/ui-app/client/src/components/FileSelector/fileSelectorProperties.ts
+++ b/ui-app/client/src/components/FileSelector/fileSelectorProperties.ts
@@ -204,6 +204,14 @@ const propertiesDefinition: Array<ComponentPropertyDefinition> = [
 	COMMON_COMPONENT_PROPERTIES.onSelect,
 	COMMON_COMPONENT_PROPERTIES.readOnly,
 	COMMON_COMPONENT_PROPERTIES.visibility,
+	{
+		name: 'allowMultipleSelection',
+		schema: SCHEMA_BOOL_COMP_PROP,
+		displayName: 'Allow Multiple Selection',
+		description: 'Allow multiple files to be selected and if there is an edit option',
+		defaultValue: false,
+		group: ComponentPropertyGroup.BASIC,
+	},
 ];
 
 const stylePropertiesDefinition: ComponentStylePropertyDefinition = {


### PR DESCRIPTION
- Introduced new property `allowMultipleSelection` to enable multiple file selection
- Updated FileSelector and LazyFileBrowser components to support the new option
- Removed unnecessary console.log in LazyFileBrowser
- Added property configuration in fileSelectorProperties.ts