### PR TITLE
Nclc2 150 file upload max file size limit

### DIFF
--- a/ui-app/client/src/components/FileUpload/FileUpload.tsx
+++ b/ui-app/client/src/components/FileUpload/FileUpload.tsx
@@ -207,12 +207,14 @@ function FileUpload(props: Readonly<ComponentProps>) {
 			const oversizedFiles = Array.from(files).filter(file => file.size > maxSizeInBytes);
 
 			if (oversizedFiles.length > 0) {
-				addMessage(
-					MESSAGE_TYPE.ERROR,
-					`File size ${returnFileSize(oversizedFiles[0].size)} exceeds maximum allowed size of ${returnFileSize(maxSizeInBytes)}`,
-					true,
-					props.context.pageName,
-				);
+				oversizedFiles.forEach(file => {
+					addMessage(
+						MESSAGE_TYPE.ERROR,
+						`File "${file.name}" (${returnFileSize(file.size)}) exceeds maximum allowed size of ${returnFileSize(maxSizeInBytes)}`,
+						true,
+						props.context.pageName,
+					);
+				});
 				return;
 			}
 		}

--- a/ui-app/client/src/components/FileUpload/FileUpload.tsx
+++ b/ui-app/client/src/components/FileUpload/FileUpload.tsx
@@ -202,6 +202,21 @@ function FileUpload(props: Readonly<ComponentProps>) {
 	const setFiles = async (files: FileList | null) => {
 		if (!files?.length) return;
 
+		if (maxFileSize) {
+			const maxSizeInBytes = parseInt(maxFileSize) * 1024 * 1024;
+			const oversizedFiles = Array.from(files).filter(file => file.size > maxSizeInBytes);
+
+			if (oversizedFiles.length > 0) {
+				addMessage(
+					MESSAGE_TYPE.ERROR,
+					`File size ${returnFileSize(oversizedFiles[0].size)} exceeds maximum allowed size of ${maxFileSize}MB`,
+					true,
+					props.context.pageName,
+				);
+				return;
+			}
+		}
+
 		if (uploadType === 'FILE_OBJECT') {
 			setData(bindingPathPath!, isMultiple ? Array.from(files) : files[0], context?.pageName);
 			return;

--- a/ui-app/client/src/components/FileUpload/FileUpload.tsx
+++ b/ui-app/client/src/components/FileUpload/FileUpload.tsx
@@ -202,7 +202,7 @@ function FileUpload(props: Readonly<ComponentProps>) {
 	const setFiles = async (files: FileList | null) => {
 		if (!files?.length) return;
 
-		if (maxFileSize && !isNaN(parseInt(maxFileSize, 10))) {
+		if (maxFileSize && !isNaN(parseInt(maxFileSize, 10)) && parseInt(maxFileSize, 10) > 0) {
 			const maxSizeInBytes = parseInt(maxFileSize, 10);
 			const oversizedFiles = Array.from(files).filter(file => file.size > maxSizeInBytes);
 

--- a/ui-app/client/src/components/FileUpload/FileUpload.tsx
+++ b/ui-app/client/src/components/FileUpload/FileUpload.tsx
@@ -202,14 +202,14 @@ function FileUpload(props: Readonly<ComponentProps>) {
 	const setFiles = async (files: FileList | null) => {
 		if (!files?.length) return;
 
-		if (maxFileSize) {
-			const maxSizeInBytes = parseInt(maxFileSize) * 1024 * 1024;
+		if (maxFileSize && !isNaN(parseInt(maxFileSize))) {
+			const maxSizeInBytes = parseInt(maxFileSize);
 			const oversizedFiles = Array.from(files).filter(file => file.size > maxSizeInBytes);
 
 			if (oversizedFiles.length > 0) {
 				addMessage(
 					MESSAGE_TYPE.ERROR,
-					`File size ${returnFileSize(oversizedFiles[0].size)} exceeds maximum allowed size of ${maxFileSize}MB`,
+					`File size ${returnFileSize(oversizedFiles[0].size)} exceeds maximum allowed size of ${returnFileSize(maxSizeInBytes)}`,
 					true,
 					props.context.pageName,
 				);

--- a/ui-app/client/src/components/FileUpload/FileUpload.tsx
+++ b/ui-app/client/src/components/FileUpload/FileUpload.tsx
@@ -202,8 +202,8 @@ function FileUpload(props: Readonly<ComponentProps>) {
 	const setFiles = async (files: FileList | null) => {
 		if (!files?.length) return;
 
-		if (maxFileSize && !isNaN(parseInt(maxFileSize))) {
-			const maxSizeInBytes = parseInt(maxFileSize);
+		if (maxFileSize && !isNaN(parseInt(maxFileSize, 10))) {
+			const maxSizeInBytes = parseInt(maxFileSize, 10);
 			const oversizedFiles = Array.from(files).filter(file => file.size > maxSizeInBytes);
 
 			if (oversizedFiles.length > 0) {


### PR DESCRIPTION
bugfix/filesize

Introduce a check to validate file sizes against a specified maximum limit. If any file exceeds the allowed size, an error message is displayed, and the upload is aborted. This ensures compliance with file size constraints and improves user feedback.