### PR TITLE
feat(Otp): add maskValue property to hide OTP input

### DIFF
--- a/ui-app/client/src/components/Otp/Otp.tsx
+++ b/ui-app/client/src/components/Otp/Otp.tsx
@@ -48,6 +48,7 @@ function Otp(props: Readonly<ComponentProps>) {
 			valueType,
 			supportingText,
 			maskValue,
+			maskStyle,
 		} = {},
 		stylePropertiesWithPseudoStates,
 		key,
@@ -286,7 +287,9 @@ function Otp(props: Readonly<ComponentProps>) {
 							? value[index] == ' '
 								? ''
 								: maskValue
-									? '*'
+									? maskStyle === 'DOT'
+										? '•'
+										: '*'
 									: value[index]
 							: ''
 					}

--- a/ui-app/client/src/components/Otp/Otp.tsx
+++ b/ui-app/client/src/components/Otp/Otp.tsx
@@ -47,6 +47,7 @@ function Otp(props: Readonly<ComponentProps>) {
 			otpLength,
 			valueType,
 			supportingText,
+			maskValue,
 		} = {},
 		stylePropertiesWithPseudoStates,
 		key,
@@ -132,25 +133,23 @@ function Otp(props: Readonly<ComponentProps>) {
 	const handlePaste = (e: React.ClipboardEvent<HTMLInputElement>, index: number) => {
 		e.preventDefault();
 		const pastedData = e.clipboardData.getData('text');
-		if(!isValidInputValue(pastedData, valueType)) return;
+		if (!isValidInputValue(pastedData, valueType)) return;
 		let newValueArray = value?.split('');
-		for(let i=0; i< Math.min(pastedData.length, otpLength-index); i++) {
-				newValueArray[index+i] = pastedData[i];
+		for (let i = 0; i < Math.min(pastedData.length, otpLength - index); i++) {
+			newValueArray[index + i] = pastedData[i];
 		}
-		const newValue = newValueArray.join('')
-		if(bindingPathPath !== undefined) {
+		const newValue = newValueArray.join('');
+		if (bindingPathPath !== undefined) {
 			setData(bindingPathPath, newValue, context?.pageName);
-		}
-		else {
+		} else {
 			setValue(newValue);
 		}
-		if(index + pastedData.length < otpLength) {
+		if (index + pastedData.length < otpLength) {
 			const target = e.target as HTMLInputElement;
 			if (target.nextSibling instanceof HTMLInputElement)
 				(target.nextSibling as HTMLInputElement).focus();
-	}
-	
-}
+		}
+	};
 
 	const handleChange = (e: React.ChangeEvent<HTMLInputElement>, index: any) => {
 		setIsDirty(true);
@@ -199,18 +198,18 @@ function Otp(props: Readonly<ComponentProps>) {
 				if (nextSibling) {
 					nextSibling?.focus();
 				}
-			}else if (e.key === 'Backspace') {
+			} else if (e.key === 'Backspace') {
 				let newValueArray = value?.split('');
 				newValueArray[index] = ' ';
 				const allEmpty = newValueArray.every(char => char === ' ');
 				const newValue = allEmpty ? '' : newValueArray.join('');
-				
+
 				if (bindingPathPath !== undefined) {
 					setData(bindingPathPath, newValue, context?.pageName);
 				} else {
 					setValue(newValue);
 				}
-			
+
 				if (index > 0) {
 					e.preventDefault();
 					if (target.previousSibling instanceof HTMLInputElement) {
@@ -282,12 +281,20 @@ function Otp(props: Readonly<ComponentProps>) {
 					maxLength={1}
 					key={index}
 					disabled={readOnly}
-					value={index < value.length ? (value[index] == ' ' ? '' : value[index]) : ''}
+					value={
+						index < value.length
+							? value[index] == ' '
+								? ''
+								: maskValue
+									? '*'
+									: value[index]
+							: ''
+					}
 					onChange={e => handleChange(e, index)}
 					onFocus={() => handleFocus(index)}
 					onBlur={handleBlur}
 					onKeyDown={handleKeyDown(index)}
-					onPaste={e => handlePaste(e,index)}
+					onPaste={e => handlePaste(e, index)}
 					style={focusBoxIndex === index ? activeStyles : inputStyle}
 					className={`_inputBox ${
 						focusBoxIndex === index && focusBoxIndex != -1 ? '_isActive' : ''

--- a/ui-app/client/src/components/Otp/otpProperties.ts
+++ b/ui-app/client/src/components/Otp/otpProperties.ts
@@ -30,6 +30,28 @@ const propertiesDefinition: Array<ComponentPropertyDefinition> = [
 		group: ComponentPropertyGroup.ADVANCED	,
 		defaultValue: false,
 	},
+	{
+		name: 'maskStyle',
+		schema: SCHEMA_STRING_COMP_PROP,
+		displayName: 'Mask Style',
+		description: 'Style of the mask character',
+		editor: ComponentPropertyEditor.ENUM,
+		defaultValue: 'DOT',
+		group: ComponentPropertyGroup.ADVANCED,
+		enumValues: [
+			{
+				name: 'DOT',
+				displayName: 'Dot',
+				description: 'Mask with dot (•)',
+			},
+			{
+				name: 'ASTERISK',
+				displayName: 'Asterisk',
+				description: 'Mask with asterisk (*)',
+			}
+		],
+	},
+	
 	COMMON_COMPONENT_PROPERTIES.readOnly,
 	COMMON_COMPONENT_PROPERTIES.visibility,
 

--- a/ui-app/client/src/components/Otp/otpProperties.ts
+++ b/ui-app/client/src/components/Otp/otpProperties.ts
@@ -22,7 +22,14 @@ const propertiesDefinition: Array<ComponentPropertyDefinition> = [
 		defaultValue: false,
 		group: ComponentPropertyGroup.ADVANCED,
 	},
-
+	{
+		name: 'maskValue',
+		schema: SCHEMA_BOOL_COMP_PROP,
+		displayName: 'Mask Value',
+		description: 'Mask the value of the otp.',
+		group: ComponentPropertyGroup.ADVANCED	,
+		defaultValue: false,
+	},
 	COMMON_COMPONENT_PROPERTIES.readOnly,
 	COMMON_COMPONENT_PROPERTIES.visibility,
 


### PR DESCRIPTION
Introduce a new property `maskValue` to mask the OTP input value with asterisks for enhanced security. This change allows users to toggle the masking feature based on their requirements.