### PR TITLE
feat(PageEditor): add keyboard shortcuts for component operations

### DIFF
--- a/ui-app/client/src/components/Iframe/iframeProperties.ts
+++ b/ui-app/client/src/components/Iframe/iframeProperties.ts
@@ -45,6 +45,7 @@ const propertiesDefinition: Array<ComponentPropertyDefinition> = [
 		schema: SCHEMA_STRING_COMP_PROP,
 		displayName: 'sandbox',
 		group: ComponentPropertyGroup.ADVANCED,
+		multiValued:true,
 		description: 'Applies extra restrictions to the content in the frame. ',
 		enumValues: [
 			{


### PR DESCRIPTION
Implement keyboard shortcuts for common component operations such as delete, copy, cut, and paste. This improves user efficiency by allowing quick actions without relying solely on the UI.