### PR TITLE
refactor(PageEditor): update delete keybindings logic for consistency

### DIFF
--- a/ui-app/client/src/components/FileUpload/fileUploadProperties.ts
+++ b/ui-app/client/src/components/FileUpload/fileUploadProperties.ts
@@ -181,6 +181,7 @@ const propertiesDefinition: Array<ComponentPropertyDefinition> = [
 		displayName: 'Maximum file size (In bytes)',
 		description: 'You can set a maximum size for a file that the user can upload.',
 		group: ComponentPropertyGroup.ADVANCED,
+		defaultValue: '1000000',
 	},
 	{
 		name: 'options',

--- a/ui-app/client/src/components/FileUpload/fileUploadProperties.ts
+++ b/ui-app/client/src/components/FileUpload/fileUploadProperties.ts
@@ -181,7 +181,6 @@ const propertiesDefinition: Array<ComponentPropertyDefinition> = [
 		displayName: 'Maximum file size (In bytes)',
 		description: 'You can set a maximum size for a file that the user can upload.',
 		group: ComponentPropertyGroup.ADVANCED,
-		defaultValue: '1000000',
 	},
 	{
 		name: 'options',

--- a/ui-app/client/src/components/PageEditor/LazyPageEditor.tsx
+++ b/ui-app/client/src/components/PageEditor/LazyPageEditor.tsx
@@ -667,22 +667,22 @@ export default function LazyPageEditor(props: Readonly<ComponentProps>) {
 			}
 
 			// Copy
-			if (e.key === 'c' && e.metaKey) {
+			if (e.key === 'c' && e.metaKey && e.altKey) {
 				e.preventDefault();
 				if (e.shiftKey) {
-					// Cmd + Shift + C: Copy with events
+					// Cmd + Shift + alt + C: Copy with events
 					operations.copy(selectedComponent, true);
 				} else {
-					// Cmd + C: Copy without events
+					// Cmd + alt+ C: Copy without events
 					operations.copy(selectedComponent, false);
 				}
 			}
 
-			// Cut
-			if (e.key === 'x' && e.metaKey) {
+			// Cut cmd + alt + x
+			if (e.key === 'x' && e.metaKey && e.altKey) {
 				e.preventDefault();
 				if (e.shiftKey) {
-					// Cmd + Shift + X: Cut with events
+					// Cmd + Shift + Alt+ X: Cut with events
 					operations.cut(selectedComponent, true);
 				} else {
 					// Cmd + X: Cut without events
@@ -690,8 +690,8 @@ export default function LazyPageEditor(props: Readonly<ComponentProps>) {
 				}
 			}
 
-			// Paste
-			if (e.key === 'v' && e.metaKey) {
+			// Paste cmd + alt + v
+			if (e.key === 'v' && e.metaKey && e.altKey) {
 				e.preventDefault();
 				operations.paste(selectedComponent);
 			}

--- a/ui-app/client/src/components/PageEditor/LazyPageEditor.tsx
+++ b/ui-app/client/src/components/PageEditor/LazyPageEditor.tsx
@@ -646,62 +646,6 @@ export default function LazyPageEditor(props: Readonly<ComponentProps>) {
 	);
 
 	useEffect(() => {
-		const handleKeyboardShortcuts = (e: KeyboardEvent) => {
-			if (!selectedComponent) return;
-
-			if (e.key === 'Delete' || e.key === 'Backspace') {
-				e.preventDefault();
-				if (e.metaKey && e.shiftKey) {
-					// Cmd + Shift + Delete: Move children up and delete
-					operations.moveChildrenUpAndDelete(selectedComponent);
-				} else if (e.metaKey) {
-					// Cmd + Delete: Normal delete without events
-					operations.deleteComponent(selectedComponent, false);
-				} else if (e.altKey) {
-					// Alt/Option + Delete: Delete children only
-					operations.deleteChildrenOnlyAndSetStore(selectedComponent);
-				} else if (e.ctrlKey) {
-					// Ctrl + Delete: Delete with events
-					operations.deleteComponent(selectedComponent, true);
-				}
-			}
-
-			// Copy
-			if (e.key === 'c' && e.metaKey && e.altKey) {
-				e.preventDefault();
-				if (e.shiftKey) {
-					// Cmd + Shift + alt + C: Copy with events
-					operations.copy(selectedComponent, true);
-				} else {
-					// Cmd + alt+ C: Copy without events
-					operations.copy(selectedComponent, false);
-				}
-			}
-
-			// Cut cmd + alt + x
-			if (e.key === 'x' && e.metaKey && e.altKey) {
-				e.preventDefault();
-				if (e.shiftKey) {
-					// Cmd + Shift + Alt+ X: Cut with events
-					operations.cut(selectedComponent, true);
-				} else {
-					// Cmd + X: Cut without events
-					operations.cut(selectedComponent, false);
-				}
-			}
-
-			// Paste cmd + alt + v
-			if (e.key === 'v' && e.metaKey && e.altKey) {
-				e.preventDefault();
-				operations.paste(selectedComponent);
-			}
-		};
-
-		document.addEventListener('keydown', handleKeyboardShortcuts);
-		return () => document.removeEventListener('keydown', handleKeyboardShortcuts);
-	}, [selectedComponent, operations]);
-
-	useEffect(() => {
 		if (!defPath) return;
 		const removeListener = addListenerAndCallImmediately(
 			(_, v) => {

--- a/ui-app/client/src/components/PageEditor/LazyPageEditor.tsx
+++ b/ui-app/client/src/components/PageEditor/LazyPageEditor.tsx
@@ -652,16 +652,17 @@ export default function LazyPageEditor(props: Readonly<ComponentProps>) {
 			if (e.key === 'Delete' || e.key === 'Backspace') {
 				e.preventDefault();
 				if (e.metaKey && e.shiftKey) {
+					// Cmd + Shift + Delete: Move children up and delete
 					operations.moveChildrenUpAndDelete(selectedComponent);
 				} else if (e.metaKey) {
-					// Cmd + Delete: Delete with events
-					operations.deleteComponent(selectedComponent, true);
-				} else if (e.altKey) {
-					// Alt + Delete: Delete children only
-					operations.deleteChildrenOnlyAndSetStore(selectedComponent);
-				} else {
-					// Delete: Normal delete
+					// Cmd + Delete: Normal delete without events
 					operations.deleteComponent(selectedComponent, false);
+				} else if (e.altKey) {
+					// Alt/Option + Delete: Delete children only
+					operations.deleteChildrenOnlyAndSetStore(selectedComponent);
+				} else if (e.ctrlKey) {
+					// Ctrl + Delete: Delete with events
+					operations.deleteComponent(selectedComponent, true);
 				}
 			}
 


### PR DESCRIPTION
The delete keybindings logic in the PageEditor component has been restructured to ensure consistent behavior across different modifier key combinations. The changes include swapping the behavior of Cmd + Delete and Ctrl + Delete to align with user expectations and improve usability.

fix(FileUpload): remove default maximum file size value

The default value for the maximum file size property in the FileUpload component has been removed to allow for more flexible configuration and avoid unintended restrictions on file uploads.