### PR TITLE
fix(Dropdown.json): correct selector syntax for border-color properties

### DIFF
--- a/ui-app/client/dist/styleProperties/Dropdown.json
+++ b/ui-app/client/dist/styleProperties/Dropdown.json
@@ -298,7 +298,7 @@
 	},
 	{
 		"cp": "border-color",
-		"sel": ".comp.compDropdown<designType>._isActive<colorScheme>,",
+		"sel": ".comp.compDropdown<designType>._isActive<colorScheme>",
 		"np": true,
 		"spv": {
 			"_default-_primary": "<fontColorThree>",
@@ -328,7 +328,7 @@
 	},
 	{
 		"cp": "border-color",
-		"sel": ".comp.compDropdown<designType>._isActive<colorScheme> ._dropdownContainer,",
+		"sel": ".comp.compDropdown<designType>._isActive<colorScheme> ._dropdownContainer",
 		"np": true,
 		"spv": {
 			"_default-_primary": "<fontColorThree>",
@@ -358,7 +358,7 @@
 	},
 	{
 		"cp": "border-color",
-		"sel": " .comp.compDropdown<designType>._hasValue<colorScheme>,",
+		"sel": ".comp.compDropdown<designType>._hasValue<colorScheme>",
 		"np": true,
 		"spv": {
 			"_default-_primary": "<fontColorThree>",
@@ -490,7 +490,7 @@
 		"n": "dropdownBorderRadius<designType><colorScheme>"
 	},
 	{
-		"cp": "Border",
+		"cp": "border",
 		"sel": ".comp.compDropdown<designType><colorScheme>",
 		"np": true,
 		"spv": {


### PR DESCRIPTION
Updated the selector strings in Dropdown.json to remove trailing commas, ensuring proper CSS syntax for the border-color properties. This change enhances the styling consistency of the dropdown component.