### PR TITLE
Enhance KIRunEditor components with improved event handling and styling

### DIFF
--- a/ui-app/client/dist/css/KIRun Editor.css
+++ b/ui-app/client/dist/css/KIRun Editor.css
@@ -72,6 +72,7 @@
 	transform-origin: left top;
 	transition: transform 1s ease-in;
 	overflow: hidden;
+	user-select: none;
 }
 
 .comp.compKIRunEditor ._designer._moving {

--- a/ui-app/client/src/components/KIRunEditor/components/KIRunContextMenu.tsx
+++ b/ui-app/client/src/components/KIRunEditor/components/KIRunContextMenu.tsx
@@ -35,7 +35,9 @@ export default function KIRunContextMenu({
 				<>
 					<div
 						className="_menuItem"
-						onClick={() => {
+						onMouseDown={e => {
+							e.stopPropagation();
+							e.preventDefault();
 							if (isReadonly || !bindingPathPath) return;
 
 							const newDef = duplicate(rawDef);
@@ -56,7 +58,9 @@ export default function KIRunContextMenu({
 				<>
 					<div
 						className="_menuItem"
-						onClick={() => {
+						onMouseDown={e => {
+							e.stopPropagation();
+							e.preventDefault();
 							if (isReadonly || !bindingPathPath) return;
 							setShowAddSearch({
 								left: menu.position.left - 5,

--- a/ui-app/client/src/components/KIRunEditor/components/Search.tsx
+++ b/ui-app/client/src/components/KIRunEditor/components/Search.tsx
@@ -49,7 +49,10 @@ export default function Search({ value, options, style, onClose, onChange }: Sea
 							<div
 								className="_option"
 								key={option.value}
-								onClick={() => onChange(option.value)}
+								onMouseDown={e => {
+									e.stopPropagation();
+									e.preventDefault();
+									onChange(option.value);}}
 							>
 								{option.label ?? option.value}
 							</div>


### PR DESCRIPTION
- Added `user-select: none;` to KIRun Editor CSS to prevent text selection during interactions.
- Updated KIRunContextMenu and Search components to use `onMouseDown` instead of `onClick`, preventing event propagation and default behavior for better user experience.