### PR TITLE
fix(Otp): improve backspace handling and focus behavior

### DIFF
--- a/ui-app/client/src/components/Otp/Otp.tsx
+++ b/ui-app/client/src/components/Otp/Otp.tsx
@@ -202,19 +202,32 @@ function Otp(props: Readonly<ComponentProps>) {
 				}
 			} else if (e.key === 'Backspace') {
 				let newValueArray = value?.split('');
-				newValueArray[index] = ' ';
-				const allEmpty = newValueArray.every(char => char === ' ');
-				const newValue = allEmpty ? '' : newValueArray.join('');
+				const currentValue = newValueArray[index];
+				const isEmpty = currentValue === ' ';
 
-				if (bindingPathPath !== undefined) {
-					setData(bindingPathPath, newValue, context?.pageName);
-				} else {
-					setValue(newValue);
-				}
+				if (!isEmpty) {
+					newValueArray[index] = ' ';
+					const allEmpty = newValueArray.every(char => char === ' ');
+					const newValue = allEmpty ? '' : newValueArray.join('');
 
-				if (index > 0) {
+					if (bindingPathPath !== undefined) {
+						setData(bindingPathPath, newValue, context?.pageName);
+					} else {
+						setValue(newValue);
+					}
+				} else if (index > 0) {
 					e.preventDefault();
 					if (target.previousSibling instanceof HTMLInputElement) {
+						newValueArray[index - 1] = ' ';
+						const allEmpty = newValueArray.every(char => char === ' ');
+						const newValue = allEmpty ? '' : newValueArray.join('');
+
+						if (bindingPathPath !== undefined) {
+							setData(bindingPathPath, newValue, context?.pageName);
+						} else {
+							setValue(newValue);
+						}
+
 						target.previousSibling.focus();
 					}
 				}
@@ -257,7 +270,7 @@ function Otp(props: Readonly<ComponentProps>) {
 			<span
 				style={computedStyles.supportText ?? {}}
 				className={`_supportText ${readOnly ? 'disabled' : ''} ${
-					focusBoxIndex != -1 ? '_supportTextActive' : ''
+					focusBoxIndex != 0 ? '_supportTextActive' : ''
 				}`}
 			>
 				<SubHelperComponent definition={definition} subComponentName="supportText" />


### PR DESCRIPTION
Fix issue where backspace would incorrectly clear previous input when current field is empty. Also correct support text active state condition from -1 to 0.

- Only clear current field if it contains a value when backspace is pressed
- Properly clear previous field and maintain focus when backspacing on empty field
- Fix support text active state condition to match expected behavior