### PR TITLE
added  OTP input for numeric value type

### DIFF
--- a/ui-app/client/src/components/Otp/Otp.tsx
+++ b/ui-app/client/src/components/Otp/Otp.tsx
@@ -460,8 +460,9 @@ function Otp(props: Readonly<ComponentProps>) {
 			{Array.from({ length: otpLength }).map((_, index) => (
 				<input
 					autoFocus={autoFocus === true && index === 0}
-					type="text"
+					type={valueType == 'NUMERIC' ? 'tel' : 'text'}
 					name="otp"
+					inputMode={valueType == 'NUMERIC' ? 'numeric' : undefined}
 					maxLength={1}
 					key={index}
 					disabled={readOnly}


### PR DESCRIPTION
Changed OTP input type to 'tel' and set inputMode to 'numeric' when valueType is 'NUMERIC' to improve mobile usability and ensure proper keyboard display.